### PR TITLE
fix: Fetch the latest release for mp-build

### DIFF
--- a/src/lematerial_fetcher/fetcher/mp/fetch.py
+++ b/src/lematerial_fetcher/fetcher/mp/fetch.py
@@ -8,6 +8,7 @@ from lematerial_fetcher.fetch import BaseFetcher, ItemsInfo
 from lematerial_fetcher.fetcher.mp.utils import add_s3_object_to_db
 from lematerial_fetcher.utils.aws import (
     get_aws_client,
+    get_latest_collection_version_prefix,
     list_s3_objects,
 )
 from lematerial_fetcher.utils.config import FetcherConfig, load_fetcher_config
@@ -59,8 +60,23 @@ class MPFetcher(BaseFetcher):
                     f"Invalid version date format: {current_version}, will process all items"
                 )
 
+        # fetch the latest release for materialsproject-build bucket if no version is set
+        prefix = self.config.mp_bucket_prefix
+        if (
+            self.config.mp_bucket_name == "materialsproject-build"
+            and self.config.mp_bucket_prefix in ["collections", "collections/"]
+        ):
+            breakpoint()
+            prefix = get_latest_collection_version_prefix(
+                self.aws_client,
+                self.config.mp_bucket_name,
+                self.config.mp_bucket_prefix,
+                "materials",
+            )
+            logger.info(f"Using latest collection version prefix: {prefix}")
+
         object_keys = list_s3_objects(
-            self.aws_client, self.config.mp_bucket_name, self.config.mp_bucket_prefix
+            self.aws_client, self.config.mp_bucket_name, prefix
         )
 
         filtered_keys = []

--- a/src/lematerial_fetcher/utils/aws.py
+++ b/src/lematerial_fetcher/utils/aws.py
@@ -61,7 +61,25 @@ def get_latest_collection_version_prefix(
     if "CommonPrefixes" not in response or not response["CommonPrefixes"]:
         raise ValueError("No date directories found in collections/")
 
-    latest_prefix = max(prefix["Prefix"] for prefix in response["CommonPrefixes"])
+    all_prefixes = [prefix["Prefix"] for prefix in response["CommonPrefixes"]]
+    # Group prefixes by date (everything before the post part)
+    date_groups = {}
+    for prefix in all_prefixes:
+        # Remove trailing slash and split by '-post'
+        base = prefix.rstrip("/")
+        if "-post" in base:
+            date_part = base.split("-post")[0]
+            post_num = int(base.split("-post")[1]) if base.split("-post")[1] else 0
+        else:
+            date_part = base
+            post_num = 0
+
+        if date_part not in date_groups:
+            date_groups[date_part] = []
+        date_groups[date_part].append((post_num, base))
+
+    latest_date = max(date_groups.keys())
+    latest_prefix = max(date_groups[latest_date], key=lambda x: x[0])[1]
 
     if latest_prefix.endswith("/"):
         latest_prefix = latest_prefix[:-1]


### PR DESCRIPTION
When using the [materialsproject-build bucket](https://materialsproject-build.s3.amazonaws.com/index.html#collections/), we want to be automatically be able to fetch the latest release. This is done by making sure that the prefix is indeed set to the parent directory of these releases `collections/` and then picking the latest date and the latest post suffix. This will break if the structure of the bucket changes, but we can still specify an exact release in the config by pointing to the associated materials directory.