### PR TITLE
fix: Faster map with HF datasets to convert species

### DIFF
--- a/src/lematerial_fetcher/push.py
+++ b/src/lematerial_fetcher/push.py
@@ -286,6 +286,7 @@ class Push:
             dataset = dataset.map(
                 convert_species,
                 batched=True,
+                num_proc=self.config.num_workers,
                 desc="Converting species column to string",
             )
 


### PR DESCRIPTION
Uses the number of workers when processing the HF dataset. This is done when we convert the species list to a json string.