### PR TITLE
Fix(lematrho): Pass AECCAR0/AECCAR2 to chargemol for DDEC6 analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Code Rules for lematerial-fetcher
+
+1. Before writing any code, describe your approach and wait for approval. Always ask clarifying questions before writing any code if requirements are ambiguous.
+
+2. If a task requires changes to more than 3 files, stop and break it into smaller tasks first.
+
+3. After writing code, list what could break and suggest tests to cover it.
+
+4. When there's a bug, start by writing a test that reproduces it, then fix it until the test passes.
+
+5. Every time I correct you, add a new rule to the CLAUDE.md file so it never happens again.
+
+6. Before every git commit, scan the staged diff for API keys, tokens, passwords, and secrets (patterns: AKIA, hf_, sk-, Bearer, AWS_SECRET, password=). Never commit credentials.

--- a/src/lematerial_fetcher/fetcher/lematrho/pipeline.py
+++ b/src/lematerial_fetcher/fetcher/lematrho/pipeline.py
@@ -118,8 +118,8 @@ PARQUET_SCHEMA = pa.schema(
 
 # Files needed for Bader analysis (must keep raw bytes)
 _BADER_FILES = {"CHGCAR.gz", "AECCAR0.gz", "AECCAR2.gz"}
-# Files needed for DDEC6 analysis
-_DDEC6_FILES = {"CHGCAR.gz"}
+# Files needed for DDEC6/chargemol analysis (AECCAR0+AECCAR2 needed for core-charge correction)
+_DDEC6_FILES = {"CHGCAR.gz", "AECCAR0.gz", "AECCAR2.gz"}
 
 
 def _structure_to_row(
@@ -546,9 +546,11 @@ class LeMatRhoDirectPipeline:
                     structure, raw_files, tool_paths["bader_path"], material_id
                 )
 
-            # Step 4: DDEC6 analysis (if tools available and CHGCAR downloaded)
+            # Step 4: DDEC6 analysis (if tools available and all required files downloaded)
             ddec6_charges = None
-            if tool_paths["can_run_ddec6"] and "CHGCAR" in raw_files:
+            if tool_paths["can_run_ddec6"] and all(
+                k in raw_files for k in ["CHGCAR", "AECCAR0", "AECCAR2"]
+            ):
                 ddec6_charges = run_ddec6_from_bytes(
                     structure,
                     raw_files,

--- a/src/lematerial_fetcher/fetcher/lematrho/utils.py
+++ b/src/lematerial_fetcher/fetcher/lematrho/utils.py
@@ -248,8 +248,10 @@ def run_ddec6_from_bytes(
 ) -> Optional[list[float]]:
     """Run DDEC6 charge analysis from raw decompressed VASP file bytes.
 
-    Writes CHGCAR and POTCAR to a temp directory, then delegates to
-    ``ChargemolAnalysis`` which runs chargemol and parses DDEC6 charges.
+    Writes CHGCAR, AECCAR0, AECCAR2, and POTCAR to a temp directory, then
+    delegates to ``ChargemolAnalysis`` which runs chargemol and parses DDEC6
+    charges.  All four files are required by chargemol: AECCAR0 and AECCAR2
+    provide the all-electron density used for core-charge correction in DDEC6.
 
     Note: Temporarily sets the ``CHARGEMOL_COMMAND`` env var for pymatgen.
     This is process-safe (``ProcessPoolExecutor`` gives each worker its own
@@ -257,7 +259,7 @@ def run_ddec6_from_bytes(
 
     Args:
         structure: Pymatgen Structure for POTCAR generation.
-        raw_files: Mapping with at least ``{"CHGCAR": b"..."}``.
+        raw_files: Mapping with ``{"CHGCAR": b"...", "AECCAR0": b"...", "AECCAR2": b"..."}``.
         chargemol_path: Path to the chargemol executable.
         atomic_densities_path: Path to atomic densities directory.
         material_id: Material identifier, used for logging.
@@ -267,8 +269,9 @@ def run_ddec6_from_bytes(
     """
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, "CHGCAR"), "wb") as f:
-                f.write(raw_files["CHGCAR"])
+            for name in ["CHGCAR", "AECCAR0", "AECCAR2"]:
+                with open(os.path.join(tmpdir, name), "wb") as f:
+                    f.write(raw_files[name])
 
             write_potcar(structure, tmpdir)
 

--- a/tests/fetcher/lematrho/test_lematrho_pipeline.py
+++ b/tests/fetcher/lematrho/test_lematrho_pipeline.py
@@ -1064,7 +1064,7 @@ class TestDdec6FromBytes:
         structure = Structure(
             Lattice.cubic(3.0), ["Si", "O"], [[0, 0, 0], [0.5, 0.5, 0.5]]
         )
-        raw_files = {"CHGCAR": b"chgcar_data"}
+        raw_files = {"CHGCAR": b"chgcar_data", "AECCAR0": b"aeccar0_data", "AECCAR2": b"aeccar2_data"}
 
         mock_ca = MagicMock()
         mock_ca.ddec_charges = [0.5, -0.5]
@@ -1081,6 +1081,40 @@ class TestDdec6FromBytes:
             )
 
         assert result == [0.5, -0.5]
+
+    def test_aeccar_files_written_to_tmpdir(self):
+        """run_ddec6_from_bytes must write AECCAR0 and AECCAR2 to tmpdir before calling ChargemolAnalysis."""
+        from pymatgen.core import Lattice, Structure
+
+        structure = Structure(Lattice.cubic(3.0), ["Si"], [[0, 0, 0]])
+        raw_files = {
+            "CHGCAR": b"chgcar",
+            "AECCAR0": b"aeccar0",
+            "AECCAR2": b"aeccar2",
+        }
+
+        observed_files = []
+
+        def capture_files(path, **kwargs):
+            observed_files.extend(os.listdir(path))
+            mock_ca = MagicMock()
+            mock_ca.ddec_charges = [0.1]
+            return mock_ca
+
+        with (
+            patch("lematerial_fetcher.fetcher.lematrho.utils.write_potcar"),
+            patch(
+                "lematerial_fetcher.fetcher.lematrho.utils.ChargemolAnalysis",
+                side_effect=capture_files,
+            ),
+        ):
+            result = run_ddec6_from_bytes(
+                structure, raw_files, "/usr/bin/chargemol", "/opt/densities", "mp-test"
+            )
+
+        assert result == [0.1]
+        assert "AECCAR0" in observed_files, "AECCAR0 must be written to tmpdir"
+        assert "AECCAR2" in observed_files, "AECCAR2 must be written to tmpdir"
 
     def test_env_var_restored_on_failure(self):
         """CHARGEMOL_COMMAND env var should be restored after ChargemolAnalysis raises."""
@@ -1529,6 +1563,60 @@ class TestProcessMaterialWithDdec6:
         assert result["ddec6_charges"] == [0.3, -0.3]
         assert result["bader_charges"] is None
         mock_ddec6.assert_called_once()
+        # AECCAR0 and AECCAR2 must be in the raw_files passed to run_ddec6_from_bytes
+        raw_files_arg = mock_ddec6.call_args[0][1]
+        assert "AECCAR0" in raw_files_arg, "AECCAR0 must be passed to run_ddec6_from_bytes"
+        assert "AECCAR2" in raw_files_arg, "AECCAR2 must be passed to run_ddec6_from_bytes"
+
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.run_ddec6_from_bytes")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_optimade_from_pymatgen")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.compress_chgcar")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.parse_vasprun_output")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.download_gz_file_from_s3")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_aws_client")
+    def test_ddec6_skips_when_aeccar_missing(
+        self,
+        mock_get_client,
+        mock_download,
+        mock_parse_vasprun,
+        mock_compress,
+        mock_get_optimade,
+        mock_ddec6,
+        mock_config,
+    ):
+        """When AECCAR files are absent from S3, DDEC6 is skipped entirely."""
+        from pymatgen.core import Lattice, Structure
+
+        mock_get_client.return_value = MagicMock()
+
+        def download_side_effect(client, bucket, key):
+            if "AECCAR" in key:
+                raise Exception("NoSuchKey")
+            return b"mock_bytes"
+
+        mock_download.side_effect = download_side_effect
+
+        structure = Structure(
+            Lattice.cubic(3.0), ["Si", "O"], [[0, 0, 0], [0.5, 0.5, 0.5]]
+        )
+        mock_parse_vasprun.return_value = (structure, None, None, None)
+        mock_compress.return_value = [[[1.0]]]
+        mock_get_optimade.return_value = _make_mock_optimade_dict()
+
+        tools = {
+            "bader_path": None,
+            "chargemol_path": "/usr/bin/chargemol",
+            "atomic_densities_path": "/opt/densities",
+            "can_generate_potcar": True,
+            "can_run_bader": False,
+            "can_run_ddec6": True,
+        }
+
+        result = LeMatRhoDirectPipeline._process_material("mp-123", mock_config, tools)
+
+        assert result is not None
+        assert result["ddec6_charges"] is None
+        mock_ddec6.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Pass AECCAR0/AECCAR2 to chargemol for DDEC6 analysis**

  ChargemolAnalysis requires AECCAR0 and AECCAR2 for core-charge correction
  in DDEC6, not just CHGCAR and POTCAR.

  - Expand `_DDEC6_FILES` to include `AECCAR0.gz` and `AECCAR2.gz`
  - Tighten the DDEC6 guard to skip silently when AECCAR files are absent (mirrors Bader
  pattern)
  - Write all three files to tmpdir in `run_ddec6_from_bytes` before calling
  `ChargemolAnalysis`
  - 3 new TDD tests: files written to tmpdir, charges populated, skip when AECCAR missin