### PR TITLE
feat(lematrho): adaptive grid shape + tqdm progress bar

### DIFF
--- a/src/lematerial_fetcher/fetcher/lematrho/pipeline.py
+++ b/src/lematerial_fetcher/fetcher/lematrho/pipeline.py
@@ -24,6 +24,7 @@ from lematerial_fetcher.fetcher.lematrho.utils import (
     STATIC_FILES,
     VALID_PREFIXES,
     compress_chgcar,
+    compute_grid_shape,
     download_gz_file_from_s3,
     get_cross_compatibility,
     parse_vasprun_output,
@@ -291,6 +292,19 @@ class LeMatRhoDirectPipeline:
         processed_count = 0
         failed_count = 0
 
+        from tqdm import tqdm
+
+        pbar = tqdm(
+            total=len(remaining),
+            unit="material",
+            desc="Processing",
+            dynamic_ncols=True,
+        )
+
+        def _update_pbar():
+            pbar.update(1)
+            pbar.set_postfix(ok=processed_count, fail=failed_count, refresh=False)
+
         if self.debug:
             for material_id in remaining:
                 result = self._process_material(
@@ -311,11 +325,7 @@ class LeMatRhoDirectPipeline:
                     buffer_ids.clear()
                     chunk_index += 1
 
-                total = processed_count + failed_count
-                if total % self.config.log_every == 0 and total > 0:
-                    logger.info(
-                        f"Progress: {processed_count} processed, {failed_count} failed"
-                    )
+                _update_pbar()
         else:
             # Worker count is intentionally low (default 4). The bottleneck is
             # memory, not CPU: each worker holds multiple decompressed CHGCAR
@@ -367,6 +377,8 @@ class LeMatRhoDirectPipeline:
                             buffer_ids.clear()
                             chunk_index += 1
 
+                        _update_pbar()
+
                         # Submit replacement (work-stealing)
                         try:
                             next_id = next(remaining_iter)
@@ -380,12 +392,7 @@ class LeMatRhoDirectPipeline:
                         except StopIteration:
                             pass
 
-                    total = processed_count + failed_count
-                    if total % self.config.log_every == 0 and total > 0:
-                        logger.info(
-                            f"Progress: {processed_count} processed, "
-                            f"{failed_count} failed"
-                        )
+        pbar.close()
 
         # Write remaining buffer
         if buffer:
@@ -477,6 +484,8 @@ class LeMatRhoDirectPipeline:
             Flat dict matching ``PARQUET_COLUMNS``, or ``None`` on failure.
         """
         bucket = config.lematrho_bucket_name
+        # Start with the fixed grid shape; may be overridden below if adaptive
+        # resolution is configured (requires vasprun lattice, parsed on first file).
         grid_shape = config.lematrho_grid_shape
 
         try:
@@ -508,6 +517,26 @@ class LeMatRhoDirectPipeline:
                     raw_bytes = LeMatRhoDirectPipeline._download_with_retry(
                         aws_client, bucket, s3_key
                     )
+
+                    # After downloading vasprun.xml (always first in STATIC_FILES),
+                    # compute adaptive grid shape from the structure's lattice if
+                    # lematrho_grid_resolution is configured.  This runs before any
+                    # charge-density file compression so grid_shape is correct for
+                    # the subsequent CHGCAR / AECCAR downloads.
+                    if (
+                        filename == "vasprun.xml.gz"
+                        and config.lematrho_grid_resolution is not None
+                    ):
+                        try:
+                            _s, _, _, _ = parse_vasprun_output(raw_bytes)
+                            grid_shape = compute_grid_shape(
+                                _s.lattice.abc, config.lematrho_grid_resolution
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Adaptive grid compute failed for {material_id}, "
+                                f"falling back to fixed {grid_shape}: {e}"
+                            )
 
                     # Compress charge density files via pyrho (skip vasprun.xml)
                     if filename in GRID_KEY_MAP:
@@ -719,9 +748,11 @@ class LeMatRhoDirectPipeline:
         dataset = load_dataset("parquet", data_files=parquet_files)
 
         logger.info(f"Pushing to HuggingFace repo: {self.config.hf_repo_id}")
-        dataset["train"].push_to_hub(
-            self.config.hf_repo_id,
-            token=self.config.hf_token,
-            private=True,
-        )
+        push_kwargs = {
+            "token": self.config.hf_token,
+            "private": True,
+        }
+        if self.config.hf_config_name:
+            push_kwargs["config_name"] = self.config.hf_config_name
+        dataset["train"].push_to_hub(self.config.hf_repo_id, **push_kwargs)
         logger.info("Push complete.")

--- a/src/lematerial_fetcher/fetcher/lematrho/utils.py
+++ b/src/lematerial_fetcher/fetcher/lematrho/utils.py
@@ -8,6 +8,7 @@ charge-analysis wrappers built on pymatgen's ``BaderAnalysis`` and
 """
 
 import gzip
+import math
 import os
 import tempfile
 from typing import Any, Optional
@@ -134,6 +135,25 @@ def parse_vasprun_output(
             pass
 
         return structure, forces_out, stress_out, energy_out
+
+
+def compute_grid_shape(
+    lattice_abc: tuple[float, float, float],
+    resolution: float,
+) -> tuple[int, int, int]:
+    """Compute a per-material charge-density grid shape from lattice lengths.
+
+    Each dimension is ``max(5, ceil(length / resolution))``, giving a fixed
+    spatial resolution in Å/point while clamping degenerate sub-1 Å dimensions.
+
+    Args:
+        lattice_abc: Lattice vector lengths (a, b, c) in Å.
+        resolution: Target spatial resolution in Å per grid point (e.g. 0.2).
+
+    Returns:
+        3-tuple of grid dimensions (nx, ny, nz).
+    """
+    return tuple(max(5, math.ceil(l / resolution)) for l in lattice_abc)
 
 
 def compress_chgcar(chgcar_bytes: bytes, grid_shape: tuple[int, int, int]) -> list:

--- a/src/lematerial_fetcher/utils/cli.py
+++ b/src/lematerial_fetcher/utils/cli.py
@@ -303,6 +303,28 @@ def add_lematrho_direct_options(f):
             help="Grid shape for pyrho charge density compression (nx ny nz).",
         ),
         click.option(
+            "--grid-resolution",
+            type=float,
+            default=None,
+            envvar="LEMATERIALFETCHER_LEMATRHO_GRID_RESOLUTION",
+            help=(
+                "Adaptive grid resolution in Å/point (e.g. 0.2). "
+                "When set, overrides --grid-shape with a per-material grid computed "
+                "as max(5, ceil(lattice_length / resolution)) per axis."
+            ),
+        ),
+        click.option(
+            "--hf-config-name",
+            type=str,
+            default=None,
+            envvar="LEMATERIALFETCHER_HF_CONFIG_NAME",
+            help=(
+                "Named HuggingFace dataset config/subset (e.g. 'adaptive-grid'). "
+                "When set, data is pushed under this config name in the HF repo. "
+                "If not set, uses the default config."
+            ),
+        ),
+        click.option(
             "--hf-repo-id",
             type=str,
             default=None,

--- a/src/lematerial_fetcher/utils/config.py
+++ b/src/lematerial_fetcher/utils/config.py
@@ -52,6 +52,9 @@ class LeMatRhoDirectPipelineConfig:
     # S3 source
     lematrho_bucket_name: str = "lemat-rho"
     lematrho_grid_shape: tuple[int, int, int] = (15, 15, 15)
+    # When set, overrides lematrho_grid_shape with a per-material adaptive grid
+    # computed as max(5, ceil(lattice_length / resolution)) per axis.
+    lematrho_grid_resolution: Optional[float] = None
     # Output
     output_dir: str = "./lematrho_output"
     parquet_chunk_size: int = 1000
@@ -62,6 +65,8 @@ class LeMatRhoDirectPipelineConfig:
     # HuggingFace (optional)
     hf_repo_id: Optional[str] = None
     hf_token: Optional[str] = None
+    # Named HF dataset config/subset (e.g. "adaptive-grid"). None → default config.
+    hf_config_name: Optional[str] = None
     # External tools (all optional — missing tools result in None fields)
     bader_path: Optional[str] = None
     chargemol_path: Optional[str] = None
@@ -427,6 +432,7 @@ def load_push_config(
 def load_direct_pipeline_config(
     lematrho_bucket_name: str = "lemat-rho",
     grid_shape: tuple[int, int, int] = (15, 15, 15),
+    grid_resolution: Optional[float] = None,
     output_dir: str = "./lematrho_output",
     parquet_chunk_size: int = 1000,
     num_workers: int = 4,
@@ -434,6 +440,7 @@ def load_direct_pipeline_config(
     limit: Optional[int] = None,
     hf_repo_id: Optional[str] = None,
     hf_token: Optional[str] = None,
+    hf_config_name: Optional[str] = None,
     bader_path: Optional[str] = None,
     chargemol_path: Optional[str] = None,
     atomic_densities_path: Optional[str] = None,
@@ -447,6 +454,7 @@ def load_direct_pipeline_config(
     return LeMatRhoDirectPipelineConfig(
         lematrho_bucket_name=lematrho_bucket_name,
         lematrho_grid_shape=grid_shape,
+        lematrho_grid_resolution=grid_resolution,
         output_dir=output_dir,
         parquet_chunk_size=parquet_chunk_size,
         num_workers=num_workers,
@@ -454,6 +462,7 @@ def load_direct_pipeline_config(
         limit=limit,
         hf_repo_id=hf_repo_id,
         hf_token=hf_token,
+        hf_config_name=hf_config_name,
         bader_path=bader_path,
         chargemol_path=chargemol_path,
         atomic_densities_path=atomic_densities_path,

--- a/tests/fetcher/lematrho/test_lematrho_pipeline.py
+++ b/tests/fetcher/lematrho/test_lematrho_pipeline.py
@@ -1696,3 +1696,141 @@ class TestIntegrationS3:
         assert result["functional"] == "r2scan"
         for col in PARQUET_COLUMNS:
             assert col in result
+
+
+# ---------------------------------------------------------------------------
+# TestComputeGridShape
+# ---------------------------------------------------------------------------
+
+
+class TestComputeGridShape:
+    def test_symmetric_cell(self):
+        """Cubic 5 Å cell at 0.2 Å/pt → ceil(5/0.2)=25 per axis."""
+        from lematerial_fetcher.fetcher.lematrho.utils import compute_grid_shape
+
+        assert compute_grid_shape((5.0, 5.0, 5.0), 0.2) == (25, 25, 25)
+
+    def test_asymmetric_cell(self):
+        """Non-cubic cell gives different grid dims per axis."""
+        from lematerial_fetcher.fetcher.lematrho.utils import compute_grid_shape
+
+        # ceil(4/0.2)=20, ceil(6/0.2)=30, ceil(3/0.2)=15
+        assert compute_grid_shape((4.0, 6.0, 3.0), 0.2) == (20, 30, 15)
+
+    def test_ceil_rounds_up(self):
+        """Non-exact division always rounds up (ceiling)."""
+        from lematerial_fetcher.fetcher.lematrho.utils import compute_grid_shape
+
+        # ceil(5.1/0.2) = ceil(25.5) = 26
+        assert compute_grid_shape((5.1, 5.1, 5.1), 0.2) == (26, 26, 26)
+
+    def test_min_floor_applied(self):
+        """Sub-1 Å dimension clamps to minimum of 5."""
+        from lematerial_fetcher.fetcher.lematrho.utils import compute_grid_shape
+
+        # ceil(0.5/0.2) = ceil(2.5) = 3 → max(5, 3) = 5
+        assert compute_grid_shape((0.5, 5.0, 5.0), 0.2) == (5, 25, 25)
+
+    def test_coarser_resolution(self):
+        """Coarser resolution (0.5 Å/pt) yields smaller grid."""
+        from lematerial_fetcher.fetcher.lematrho.utils import compute_grid_shape
+
+        # ceil(10/0.5)=20, ceil(5/0.5)=10, ceil(3/0.5)=6
+        assert compute_grid_shape((10.0, 5.0, 3.0), 0.5) == (20, 10, 6)
+
+
+# ---------------------------------------------------------------------------
+# TestAdaptiveGridShape
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveGridShape:
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_optimade_from_pymatgen")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.compress_chgcar")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.parse_vasprun_output")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.download_gz_file_from_s3")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_aws_client")
+    def test_uses_lattice_when_resolution_set(
+        self,
+        mock_get_client,
+        mock_download,
+        mock_parse,
+        mock_compress,
+        mock_get_optimade,
+        tmp_output_dir,
+        no_tools,
+    ):
+        """When lematrho_grid_resolution is set, grid_shape derives from structure lattice."""
+        from pymatgen.core import Lattice, Structure
+
+        mock_get_client.return_value = MagicMock()
+        mock_download.return_value = b"mock_bytes"
+
+        # 10×5×3 Å cell → at 0.2 Å/pt: ceil(10/0.2)=50, ceil(5/0.2)=25, ceil(3/0.2)=15
+        structure = Structure(
+            Lattice([[10.0, 0, 0], [0, 5.0, 0], [0, 0, 3.0]]),
+            ["Si", "O"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+        )
+        mock_parse.return_value = (structure, None, None, None)
+        mock_compress.return_value = [[[1.0]]]
+        mock_get_optimade.return_value = _make_mock_optimade_dict()
+
+        config = LeMatRhoDirectPipelineConfig(
+            lematrho_bucket_name="test-bucket",
+            lematrho_grid_shape=(15, 15, 15),  # must NOT be used
+            lematrho_grid_resolution=0.2,
+            output_dir=tmp_output_dir,
+        )
+
+        result = LeMatRhoDirectPipeline._process_material("mp-123", config, no_tools)
+
+        assert result is not None
+        assert result["charge_density_grid_shape"] == [50, 25, 15]
+        # Every compress_chgcar call must use the adaptive shape, not the fixed one
+        for call in mock_compress.call_args_list:
+            assert call[0][1] == (50, 25, 15)
+
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_optimade_from_pymatgen")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.compress_chgcar")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.parse_vasprun_output")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.download_gz_file_from_s3")
+    @patch("lematerial_fetcher.fetcher.lematrho.pipeline.get_aws_client")
+    def test_uses_fixed_shape_when_no_resolution(
+        self,
+        mock_get_client,
+        mock_download,
+        mock_parse,
+        mock_compress,
+        mock_get_optimade,
+        tmp_output_dir,
+        no_tools,
+    ):
+        """When lematrho_grid_resolution is None, fixed grid_shape is used unchanged."""
+        from pymatgen.core import Lattice, Structure
+
+        mock_get_client.return_value = MagicMock()
+        mock_download.return_value = b"mock_bytes"
+
+        structure = Structure(
+            Lattice([[10.0, 0, 0], [0, 5.0, 0], [0, 0, 3.0]]),
+            ["Si", "O"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+        )
+        mock_parse.return_value = (structure, None, None, None)
+        mock_compress.return_value = [[[1.0]]]
+        mock_get_optimade.return_value = _make_mock_optimade_dict()
+
+        config = LeMatRhoDirectPipelineConfig(
+            lematrho_bucket_name="test-bucket",
+            lematrho_grid_shape=(7, 8, 9),
+            lematrho_grid_resolution=None,  # adaptive OFF
+            output_dir=tmp_output_dir,
+        )
+
+        result = LeMatRhoDirectPipeline._process_material("mp-123", config, no_tools)
+
+        assert result is not None
+        assert result["charge_density_grid_shape"] == [7, 8, 9]
+        for call in mock_compress.call_args_list:
+            assert call[0][1] == (7, 8, 9)


### PR DESCRIPTION
## Summary

- **Adaptive charge density grid**: `--grid-resolution 0.2` computes per-material grid shape as `max(5, ceil(lattice_length / resolution))` per axis, so larger unit cells get proportionally more grid points. Falls back to fixed `--grid-shape` when not set.
- **HF config name**: `--hf-config-name adaptive-grid` pushes to a named config/subset in the HF repo, enabling multiple dataset versions at the same URL.
- **tqdm progress bar**: replaces `log_every`-based log lines with a live bar showing processed/failed counts and ETA, for both sequential (debug) and parallel modes.

## New env vars

| Variable | Example |
|---|---|
| `LEMATERIALFETCHER_LEMATRHO_GRID_RESOLUTION` | `0.2` |
| `LEMATERIALFETCHER_HF_CONFIG_NAME` | `adaptive-grid` |

## Test plan

- [x] `TestComputeGridShape` (5 tests): symmetric, asymmetric, ceiling rounding, min floor, coarser resolution
- [x] `TestAdaptiveGridShape` (2 tests): adaptive shape used when resolution set; fixed shape used when None
- [x] Full test suite: 55 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)