### PR TITLE
fix: off-by-one in fetch_items_iter drops one row from every transform run

### DIFF
--- a/.github/workflows/main_checks.yaml
+++ b/.github/workflows/main_checks.yaml
@@ -13,6 +13,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: lematerial
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ material-hasher = { git = "https://github.com/LeMaterial/lematerial-hasher.git" 
 [tool.pytest.ini_options]
 markers = [
     "integration: tests that require real AWS credentials and S3 access (deselect with '-m \"not integration\"')",
+    "postgres: tests that require a running PostgreSQL server, skipped automatically if none is reachable (deselect with '-m \"not postgres\"')",
 ]
 
 [tool.ruff.lint]

--- a/src/lematerial_fetcher/database/postgres.py
+++ b/src/lematerial_fetcher/database/postgres.py
@@ -285,12 +285,14 @@ class StructuresDatabase(Database):
                     if not start_id:  # No results at this offset
                         return
 
-                # Construct the query based on whether we have a start_id
+                # Construct the query based on whether we have a start_id.
+                # start_id is the id *at* the requested offset (0-based), so the
+                # scan must be inclusive: `>` would drop the boundary row itself.
                 if start_id:
                     query = f"""
                     SELECT id, type, attributes, last_modified
                     FROM {table_name}
-                    WHERE id > %s
+                    WHERE id >= %s
                     ORDER BY id
                     {f"LIMIT {limit}" if limit is not None else ""}
                     """

--- a/tests/database/test_postgres.py
+++ b/tests/database/test_postgres.py
@@ -1,0 +1,125 @@
+# Copyright 2025 Entalpic
+"""Regression tests for offset pagination in ``StructuresDatabase``.
+
+These tests run against a real PostgreSQL server, because the bug they guard
+against lives in the SQL itself (``WHERE id > start_id`` vs ``WHERE id >= start_id``)
+and a mocked cursor cannot catch it.
+
+They are skipped automatically when no server is reachable. To run them locally:
+
+.. code-block:: bash
+
+    docker run -d --name lemat-test-pg \\
+        -e POSTGRES_USER=root -e POSTGRES_PASSWORD=root -e POSTGRES_DB=lematerial \\
+        -p 5432:5432 postgres:16
+    uv run pytest tests/database/ -m postgres
+
+Set ``LEMATERIALFETCHER_TEST_DB_CONN_STR`` to point at a different server.
+"""
+
+import os
+import uuid
+
+import psycopg2
+import pytest
+
+from lematerial_fetcher.database.postgres import StructuresDatabase
+from lematerial_fetcher.models.models import RawStructure
+
+DEFAULT_CONN_STR = (
+    "host=localhost user=root password=root dbname=lematerial sslmode=disable"
+)
+CONN_STR = os.environ.get("LEMATERIALFETCHER_TEST_DB_CONN_STR", DEFAULT_CONN_STR)
+
+pytestmark = pytest.mark.postgres
+
+
+def _postgres_available() -> bool:
+    try:
+        psycopg2.connect(CONN_STR).close()
+        return True
+    except psycopg2.OperationalError:
+        return False
+
+
+@pytest.fixture
+def db():
+    """A StructuresDatabase backed by a uniquely-named, throwaway table."""
+    if not _postgres_available():
+        pytest.skip(
+            "No PostgreSQL server available "
+            "(set LEMATERIALFETCHER_TEST_DB_CONN_STR or start a local server)"
+        )
+    table_name = f"test_structures_{uuid.uuid4().hex[:12]}"
+    database = StructuresDatabase(CONN_STR, table_name)
+    database.create_table()
+    yield database
+    with database.conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {table_name};")
+    database.conn.commit()
+    database.close()
+
+
+def insert_rows(db: StructuresDatabase, n: int) -> list[str]:
+    """Insert n rows with ids that sort in insertion order, return the ids."""
+    ids = [f"struct-{i:03d}" for i in range(n)]
+    db.batch_insert_data(
+        [
+            RawStructure(
+                id=id_,
+                type="test-structure",
+                attributes={"index": i},
+                last_modified=None,
+            )
+            for i, id_ in enumerate(ids)
+        ]
+    )
+    return ids
+
+
+def test_fetch_items_iter_starts_at_offset(db):
+    """fetch_items_iter(offset=k) must start at the row at rank k, not k+1."""
+    ids = insert_rows(db, 10)
+    got = [row.id for row in db.fetch_items_iter(offset=4, limit=3)]
+    assert got == ids[4:7]
+
+
+def test_fetch_items_returns_row_at_offset(db):
+    ids = insert_rows(db, 10)
+    rows = db.fetch_items(offset=3, batch_size=1)
+    assert [row.id for row in rows] == [ids[3]]
+
+
+def test_batched_pagination_covers_every_row_exactly_once(db):
+    """Reading a table in consecutive (offset, batch_size) windows, the way
+    BaseTransformer does, must yield every row exactly once.
+
+    Regression test: fetch_items_iter used to resolve the id *at* the offset
+    and then scan ``WHERE id > start_id``, silently dropping the row at rank
+    ``batch_size`` from every multi-batch read.
+    """
+    ids = insert_rows(db, 10)
+    batch_size = 3
+
+    seen = []
+    offset = 0
+    while True:
+        batch = db.fetch_items(offset=offset, batch_size=batch_size)
+        if not batch:
+            break
+        seen.extend(row.id for row in batch)
+        offset += batch_size
+
+    assert seen == ids
+
+
+def test_offset_zero_reads_from_first_row(db):
+    ids = insert_rows(db, 5)
+    got = [row.id for row in db.fetch_items_iter(offset=0)]
+    assert got == ids
+
+
+def test_offset_past_end_yields_nothing(db):
+    insert_rows(db, 5)
+    assert list(db.fetch_items_iter(offset=5)) == []
+    assert db.fetch_items(offset=99, batch_size=10) == []


### PR DESCRIPTION
## Summary

`StructuresDatabase.fetch_items_iter` has an issue with its id-based pagination logic.
When you ask `fetch_items_iter` to start reading from some `offset`, it first looks up which row sits at
that `offset` (using `get_id_at_offset`, which counts from zero), and then it fetches
rows using the condition `WHERE id > start_id`. The problem is the `>`: the row
that sits exactly at the offset gets excluded, because the query only takes rows that
come *after* it.

Here is what that looks like in practice. Take a table with 11 rows, ids `A` through
`K`, and read it in batches of 3 the way the transformers do (this is real output from
running the current code against Postgres):

```text
batch at offset 0: ['A', 'B', 'C']
batch at offset 3: ['E', 'F', 'G']   <- D is lost here
batch at offset 6: ['H', 'I', 'J']
batch at offset 9: ['K']
missing: ['D']
```

At offset 3, the code looks up the row at position 3 (that's `D`) and then fetches
`WHERE id > 'D'`, so it starts at `E` and nobody ever comes back for `D`. At offset 6
the same exclusion happens to `G`, but `G` was already returned by the previous batch
(which had shifted forward by one), so from that point on the off-by-ones cancel out.
The net result is that exactly one row goes missing per read, always the one sitting
at position `batch_size`, and it doesn't matter how many rows the table has.

This isn't specific to any one data source. The batch loop in `BaseTransformer` (which
the MP and Alexandria transforms run through) and OQMD's custom transform all paginate
through this method. So as far as I can tell, every transform run to date has quietly
lost one raw structure on its way to the clean table. Since the source tables hold
millions of rows, one missing row was effectively invisible in production. Still, it's
silent data loss in a pipeline whose whole job is faithful ingestion, and there is no
warning anywhere in the logs when it happens.

The fix itself is one character: change the scan to `WHERE id >= start_id`, so the row
at the offset is included.

## How I found it

I'm working on an AFLOW source adapter (PR coming separately), and while validating it
end-to-end against a local Postgres, fetch pulled 180 raw rows but transform produced
179 clean rows, with no skip warning in the logs. The missing row transformed fine on
its own, so the row wasn't the problem. What stood out was *where* it sat: at position
exactly 50 in the table's id ordering, which happened to be my `--batch-size`.

To rule out a coincidence, I emptied the destination table and re-ran the same
transform with `--batch-size 30`. A different row went missing, this time at position
exactly 30. The missing row moves with the batch size, which confirmed it: the row at
position `batch_size` is always dropped. At production scale (millions of rows) one
missing row is unnoticeable, which is probably why this survived so long.

## What's in this PR

- The one-character fix in `fetch_items_iter`, plus a short comment in the code
  explaining why the scan has to be inclusive.
- `tests/database/test_postgres.py`: regression tests that run against a real
  PostgreSQL server. The most important test builds a small 10-row table and reads it
  in consecutive `(offset, batch_size)` windows, exactly the way `BaseTransformer`
  does, and then checks that every row came back exactly once. Before the fix, this
  test fails with the row at position `batch_size` missing. After the fix, it passes.
  There are also more direct tests checking that `fetch_items_iter(offset=k)` and
  `fetch_items(offset=k)` really start at position k, and tests for the edges
  (offset 0, and an offset past the end of the table).
- A new `postgres` pytest marker, registered in `pyproject.toml`. If no PostgreSQL
  server is reachable, these tests skip themselves automatically, so a plain `pytest`
  run stays green on machines without Postgres. The docstring at the top of the test
  file documents the one-line docker command to run them locally.
- A separate commit that adds a `postgres:16` service to the CI workflow, so that
  these tests actually execute in CI instead of skipping. I kept it as its own commit
  on purpose, but if you would rather not touch the workflow, just drop that commit and the tests will simply skip in CI.

The reason why these new tests need a real Postgres is that the bug lives inside the SQL string itself: a mocked cursor just returns whatever it's told to, so it never really tests the pagination logic (which is why the existing test suite never caught this). Only a real Postgres can actually exercise the pagination behavior.

## How to verify the fix

- The new regression tests fail on `main` and pass with the fix (5 passed).
- The full test suite passes after the fix, and `ruff check` and
  `ruff format --check` are both clean.
- I re-ran the AFLOW end-to-end pipeline that surfaced the bug in the first place:
  the transform now produces 180 clean rows from 180 raw rows.
